### PR TITLE
fix(irc): Align client behavior with modern IRC

### DIFF
--- a/src/irc.ts
+++ b/src/irc.ts
@@ -14,7 +14,13 @@ import {
   utf8Decoder,
   utf8Encoder,
 } from './ircEncoding.js';
-import { applyIsupport } from './ircIsupport.js';
+import {
+  applyIsupport,
+  defaultChannelModes,
+  defaultChannelTypes,
+  defaultModeForPrefix,
+  defaultPrefixForMode,
+} from './ircIsupport.js';
 import { defaultOptions, type IrcOptions } from './ircOptions.js';
 import {
   type ChannelData,
@@ -32,6 +38,32 @@ const whoisTimeoutMs = 30_000;
 function isLineTerminated(bytes: Uint8Array): boolean {
   const lastByte = bytes[bytes.length - 1];
   return lastByte === 10 || lastByte === 13;
+}
+
+function containsInvalidLineByte(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code === 0 || code === 10 || code === 13) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function mustBeTrailingParam(value: string): boolean {
+  if (value === '' || value.charCodeAt(0) === 58) {
+    return true;
+  }
+
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code === 32 || code === 9 || code === 11 || code === 12) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export type { ChannelData } from './ircTypes.js';
@@ -56,13 +88,14 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
   _whoisData: Record<string, WhoIsData> = {};
   // Features supported by the server
   // (Initial values are RFC 1459 defaults. Zeros signify no default or unlimited value.)
+  // ISUPPORT defaults: https://modern.ircdocs.horse/#feature-advertisement
   supported: SupportedFeatures = {
     channel: {
       idlength: {},
       length: 200,
       limit: {},
-      modes: { a: '', b: '', c: '', d: '' },
-      types: '',
+      modes: { ...defaultChannelModes },
+      types: defaultChannelTypes,
     },
     kicklength: 0,
     maxlist: {},
@@ -74,10 +107,11 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
   };
 
   motd?: string;
-  modeForPrefix: Record<string, string> = {};
-  prefixForMode: Record<string, string> = {};
+  modeForPrefix: Record<string, string> = { ...defaultModeForPrefix };
+  prefixForMode: Record<string, string> = { ...defaultPrefixForMode };
   chans: Record<string, ChannelData> = {};
   channellist: ChannelData[] = [];
+  private channellistOpen = false;
   retryTimeout?: ReturnType<typeof setTimeout>;
   private pendingWhois = new Map<
     string,
@@ -267,13 +301,16 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
 
   send(...args: string[]) {
     // e.g. NICK, nickname
+    // IRC messages are single CRLF-delimited lines capped at 512 bytes.
+    // https://modern.ircdocs.horse/#message-format
+    for (const arg of args) {
+      if (containsInvalidLineByte(arg)) {
+        throw new Error('IRC message parameters cannot contain NUL, CR, or LF characters');
+      }
+    }
 
     // if the last arg contains a space, starts with a colon, or is empty, prepend a colon
-    if (
-      /\s/.exec(args[args.length - 1]) ||
-      /^:/.exec(args[args.length - 1]) ||
-      args[args.length - 1] === ''
-    ) {
+    if (mustBeTrailingParam(args[args.length - 1])) {
       args[args.length - 1] = `:${args[args.length - 1]}`;
     }
 
@@ -284,8 +321,13 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
     if (this.connection.requestedDisconnect) {
       this.debug('(Disconnected) SEND:', args.join(' '));
     } else {
+      const line = `${args.join(' ')}\r\n`;
+      if (utf8ByteLength(line) > 512) {
+        throw new Error('IRC messages cannot exceed 512 bytes including CRLF');
+      }
+
       this.debug('SEND:', args.join(' '));
-      this.connection.socket.write(`${args.join(' ')}\r\n`);
+      this.connection.socket.write(line);
     }
   }
 
@@ -571,6 +613,10 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
     const welcomeStringWords = message.args[1].split(/\s+/);
     this.hostMask = welcomeStringWords[welcomeStringWords.length - 1];
     this._updateMaxLineLength();
+    // Clients must answer server PINGs during registration, but only start
+    // client-initiated keepalives after registration completes.
+    // https://modern.ircdocs.horse/#connection-registration
+    this.connection.cyclingPingTimer.start();
     this.emit('registered', message);
     const res = await this.whois(this.nick);
     this.nick = res.nick ?? '';
@@ -618,7 +664,9 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
         break;
       }
       case 'PONG': {
-        this.emit('pong', message.args[0]);
+        // PONG is "[<server>] <token>"; the server name is not the opaque token.
+        // https://modern.ircdocs.horse/#pong-message
+        this.emit('pong', message.args.at(-1) ?? '');
         break;
       }
       case 'NOTICE': {
@@ -674,8 +722,14 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
         break;
       }
       case 'rpl_whoischannels': {
-        // TODO - clean this up?
-        this._addWhoisData(message.args[1], 'channels', message.args[2].trim().split(/\s+/));
+        // RPL_WHOISCHANNELS can be repeated when the list does not fit once.
+        // https://modern.ircdocs.horse/#rplwhoischannels-319
+        const existingChannels = this._whoisData[message.args[1]]?.channels;
+        const channels = Array.isArray(existingChannels) ? existingChannels : [];
+        this._addWhoisData(message.args[1], 'channels', [
+          ...channels,
+          ...message.args[2].trim().split(/\s+/),
+        ]);
         break;
       }
       case 'rpl_whoisserver': {
@@ -713,15 +767,24 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
       }
       case 'rpl_liststart': {
         this.channellist = [];
+        this.channellistOpen = true;
         this.emit('channellist_start');
         break;
       }
       case 'rpl_list': {
+        // RPL_LISTSTART may be skipped, so the first RPL_LIST starts a new list.
+        // https://modern.ircdocs.horse/#rplliststart-321
+        if (!this.channellistOpen) {
+          this.channellist = [];
+          this.channellistOpen = true;
+        }
+
         this._handleList(message);
         break;
       }
       case 'rpl_listend': {
         this.emit('channellist', this.channellist);
+        this.channellistOpen = false;
         break;
       }
       case 'rpl_topicwhotime': {
@@ -782,6 +845,15 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
       }
       case 'rpl_saslsuccess': {
         this.send('CAP', 'END');
+        break;
+      }
+      case 'err_saslfail':
+      case 'err_sasltoolong':
+      case 'err_saslaborted':
+      case 'err_saslalready': {
+        this.send('CAP', 'END');
+        this.debug(message);
+        this.emit('error', message);
         break;
       }
       case 'err_umodeunknownflag': {
@@ -1110,11 +1182,14 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
       );
     }
 
-    // SASL, server password
+    // CAP negotiation suspends registration until CAP END.
+    // https://modern.ircdocs.horse/#capability-negotiation
     if (this.opt.sasl) {
       // see http://ircv3.net/specs/extensions/sasl-3.1.html
-      this.send('CAP', 'REQ', 'sasl');
-    } else if (this.opt.password) {
+      this.send('CAP', 'LS', '302');
+    }
+
+    if (this.opt.password) {
       this.send('PASS', this.opt.password);
     }
 
@@ -1123,10 +1198,8 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
     this.send('NICK', this.opt.nick);
     this.nick = this.opt.nick;
     this._updateMaxLineLength();
-    this.send('USER', this.opt.userName, '8', '*', this.opt.realName);
-
-    // watch for ping timeout
-    this.connection.cyclingPingTimer.start();
+    // USER syntax: https://modern.ircdocs.horse/#user-message
+    this.send('USER', this.opt.userName, '0', '*', this.opt.realName);
 
     this.emit('connect');
   }
@@ -1194,7 +1267,8 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
   private _handleList(message: Message): void {
     const channel = {
       name: message.args[1],
-      users: message.args[2] as unknown as Record<string, string>,
+      users: {},
+      userCount: Number.parseInt(message.args[2], 10),
       topic: message.args[3],
     };
     this.emit('channellist_item', channel);
@@ -1261,8 +1335,20 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
     // client identifier name, cap subcommand, params
     if (message.args[1] === 'NAK') {
       // capabilities not handled, error
+      this.send('CAP', 'END');
       this.debug(message);
       this.emit('error', message);
+      return;
+    }
+
+    if (message.args[1] === 'LS') {
+      const caps = message.args.at(-1)?.split(/\s+/) ?? [];
+      if (this.opt.sasl && caps.includes('sasl')) {
+        this.send('CAP', 'REQ', 'sasl');
+      } else if (message.args[2] !== '*') {
+        this.send('CAP', 'END');
+      }
+
       return;
     }
 
@@ -1317,6 +1403,16 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
     const channel = this.chanData(message.args[1]);
     if (channel) {
       channel.mode = message.args[2];
+      channel.modeParams = {};
+      // RPL_CHANNELMODEIS includes mode arguments after the modestring.
+      // https://modern.ircdocs.horse/#rplchannelmodeis-324
+      const modeArgs = message.args.slice(3);
+      for (const mode of message.args[2].replaceAll(/[+-]/g, '')) {
+        const modeArg = modeArgs.shift();
+        if (modeArg) {
+          channel.modeParams[mode] = [modeArg];
+        }
+      }
     }
   }
 

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -1408,12 +1408,27 @@ export class IrcClient extends TypedEmitter<IrcClientEvents> {
       // https://modern.ircdocs.horse/#rplchannelmodeis-324
       const modeArgs = message.args.slice(3);
       for (const mode of message.args[2].replaceAll(/[+-]/g, '')) {
-        const modeArg = modeArgs.shift();
-        if (modeArg) {
-          channel.modeParams[mode] = [modeArg];
+        if (this.channelModeHasSnapshotArg(mode)) {
+          const modeArg = modeArgs.shift();
+          if (modeArg) {
+            channel.modeParams[mode] = [modeArg];
+          }
         }
       }
     }
+  }
+
+  private channelModeHasSnapshotArg(mode: string): boolean {
+    const { a, b, c, d } = this.supported.channel.modes;
+    if (a.includes(mode) || b.includes(mode) || c.includes(mode)) {
+      return true;
+    }
+
+    if (d.includes(mode)) {
+      return false;
+    }
+
+    return mode === 'b' || mode === 'k' || mode === 'l';
   }
 
   private _handleCreationtime(message: Message): void {

--- a/src/ircIsupport.ts
+++ b/src/ircIsupport.ts
@@ -3,6 +3,51 @@ import type { Message } from './parseMessage.js';
 
 type PrefixMap = Record<string, string>;
 
+export const defaultChannelTypes = '#&';
+export const defaultChannelModes = { a: '', b: 'ov', c: '', d: '' };
+export const defaultModeForPrefix = { '+': 'v', '@': 'o' };
+export const defaultPrefixForMode = { o: '@', v: '+' };
+/** Decodes ISUPPORT value escapes like `\x20` into their byte value. */
+const isupportEscapeRegex = /\\x([0-9A-Fa-f]{2})/g;
+/** Matches `TOKEN`, `TOKEN=value`, and `-TOKEN` forms from RPL_ISUPPORT. */
+const isupportTokenRegex = /^(-?)([A-Z0-9./]+)(?:=(.*))?$/;
+
+function clearPrefixMaps(modeForPrefix: PrefixMap, prefixForMode: PrefixMap): void {
+  for (const prefix of Object.keys(modeForPrefix)) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete modeForPrefix[prefix];
+  }
+
+  for (const mode of Object.keys(prefixForMode)) {
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete prefixForMode[mode];
+  }
+}
+
+function unescapeValue(value: string): string {
+  return value.replaceAll(isupportEscapeRegex, (_match, hex: string) =>
+    String.fromCharCode(Number.parseInt(hex, 16)),
+  );
+}
+
+function resetPrefixMaps(modeForPrefix: PrefixMap, prefixForMode: PrefixMap): void {
+  clearPrefixMaps(modeForPrefix, prefixForMode);
+  Object.assign(modeForPrefix, defaultModeForPrefix);
+  Object.assign(prefixForMode, defaultPrefixForMode);
+}
+
+function removeModes(value: string, modes: Iterable<string>): string {
+  const remove = new Set(modes);
+  let result = '';
+  for (const mode of value) {
+    if (!remove.has(mode)) {
+      result += mode;
+    }
+  }
+
+  return result;
+}
+
 export function applyIsupport(
   args: Message['args'],
   supported: SupportedFeatures,
@@ -10,17 +55,24 @@ export function applyIsupport(
   prefixForMode: PrefixMap,
 ): void {
   for (const arg of args) {
-    const match = /([A-Z]+)=(.*)/.exec(arg);
+    const match = isupportTokenRegex.exec(arg);
     if (!match) {
       continue;
     }
 
-    const param = match[1];
-    const value = match[2];
+    const removed = match[1] === '-';
+    const param = match[2];
+    const value = unescapeValue(match[3] ?? '');
     const type = ['a', 'b', 'c', 'd'] as const;
 
+    // RPL_ISUPPORT tokens and removals: https://modern.ircdocs.horse/#rplisupport-005
     switch (param) {
       case 'CHANLIMIT': {
+        if (removed) {
+          supported.channel.limit = {};
+          break;
+        }
+
         value.split(',').forEach(val => {
           const split = val.split(':');
           const limit = Number.parseInt(split[1], 10);
@@ -32,15 +84,27 @@ export function applyIsupport(
       }
 
       case 'CHANMODES': {
+        if (removed) {
+          supported.channel.modes = { ...defaultChannelModes };
+          break;
+        }
+
         const split = value.split(',');
+        supported.channel.modes = { a: '', b: '', c: '', d: '' };
         for (let i = 0; i < type.length; i++) {
           supported.channel.modes[type[i]] += split[i];
         }
+        supported.channel.modes.b += Object.keys(prefixForMode).join('');
 
         break;
       }
 
       case 'CHANTYPES': {
+        if (removed) {
+          supported.channel.types = defaultChannelTypes;
+          break;
+        }
+
         supported.channel.types = value;
         break;
       }
@@ -67,6 +131,11 @@ export function applyIsupport(
       }
 
       case 'MAXLIST': {
+        if (removed) {
+          supported.maxlist = {};
+          break;
+        }
+
         value.split(',').forEach(val => {
           const split = val.split(':');
           const max = Number.parseInt(split[1], 10);
@@ -77,12 +146,31 @@ export function applyIsupport(
         break;
       }
 
+      case 'MODES': {
+        if (removed) {
+          supported.modes = 3;
+          break;
+        }
+
+        supported.modes = Number.parseInt(value, 10);
+        break;
+      }
+
       case 'NICKLEN': {
         supported.nicklength = Number.parseInt(value, 10);
         break;
       }
 
       case 'PREFIX': {
+        const previousPrefixModes = Object.keys(prefixForMode);
+        clearPrefixMaps(modeForPrefix, prefixForMode);
+        supported.channel.modes.b = removeModes(supported.channel.modes.b, previousPrefixModes);
+        if (removed) {
+          resetPrefixMaps(modeForPrefix, prefixForMode);
+          supported.channel.modes.b += 'ov';
+          break;
+        }
+
         const prefixMatch = /\((.*?)\)(.*)/.exec(value);
         if (prefixMatch) {
           const prefixSplit = [];
@@ -99,6 +187,11 @@ export function applyIsupport(
       }
 
       case 'TARGMAX': {
+        if (removed) {
+          supported.maxtargets = {};
+          break;
+        }
+
         value.split(',').forEach(val => {
           const split = val.split(':');
           const numVal = split[1] ? Number.parseInt(split[1], 10) : 0;

--- a/src/ircOptions.ts
+++ b/src/ircOptions.ts
@@ -1,3 +1,5 @@
+import { defaultChannelTypes } from './ircIsupport.js';
+
 export interface WebIrcOptions {
   /** Password shared with the IRC gateway for `WEBIRC` authentication. */
   pass: string;
@@ -84,7 +86,7 @@ const defaultOptions: IrcOptions = {
     host: '',
   },
   stripColors: true,
-  channelPrefixes: '&#',
+  channelPrefixes: defaultChannelTypes,
   messageSplit: 512,
   encoding: null,
   millisecondsOfSilenceBeforePingSent: 15 * 1000,

--- a/src/ircTypes.ts
+++ b/src/ircTypes.ts
@@ -12,6 +12,8 @@ export type ChannelData = {
   name?: string;
   /** Known users in the channel keyed by nickname with their mode prefix value. */
   users: Record<string, string>;
+  /** Number of visible clients reported by LIST responses. */
+  userCount?: number;
   /** Parameters associated with channel modes that carry arguments. */
   modeParams?: Record<string, any>;
   /** Current raw channel mode string. */

--- a/src/parseMessage.ts
+++ b/src/parseMessage.ts
@@ -8,10 +8,60 @@ export type Message = {
   user?: string;
   host?: string;
   server?: string;
+  tags?: Record<string, string | true>;
   command: CodeNames;
   rawCommand: string;
   commandType: CommandTypes | 'normal';
 };
+
+const tagEscapes: Record<string, string> = {
+  ':': ';',
+  r: '\r',
+  n: '\n',
+  s: ' ',
+  '\\': '\\',
+};
+
+/** Matches the optional IRCv3 message tag block at the start of a line. */
+const tagPrefixRegex = /^@([^ ]+) +/;
+/** Matches the optional IRC source/prefix at the start of a line. */
+const sourcePrefixRegex = /^:([^ ]+) +/;
+/** Matches a source as a strict RFC-style nickname, with optional user and host. */
+const strictSourceRegex = /^([_a-zA-Z0-9~[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/;
+/** Matches a source as a looser nickname for networks that allow Unicode or extra symbols. */
+const looseSourceRegex =
+  /^([\u1100-\u11FF\u3040-\u309FF\u30A0-\u30FF\u3130-\u318F\u31F0-\u31FF\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF_a-zA-Z0-9~[\]\\/?`^{}|-]*)(!([^@]+)@(.*))?$/;
+
+function parseTags(rawTags: string): Record<string, string | true> {
+  const tags: Record<string, string | true> = {};
+  for (const rawTag of rawTags.split(';')) {
+    const separator = rawTag.indexOf('=');
+    if (separator === -1) {
+      tags[rawTag] = true;
+      continue;
+    }
+
+    const key = rawTag.slice(0, separator);
+    const value = rawTag.slice(separator + 1);
+    tags[key] = value.replaceAll(/\\([:rns\\])/g, (_match, escape: string) => tagEscapes[escape]);
+  }
+
+  return tags;
+}
+
+function findTrailingStart(line: string): number {
+  if (line.charCodeAt(0) === 58) {
+    return 0;
+  }
+
+  for (let i = 1; i < line.length; i++) {
+    if (line.charCodeAt(i) === 58 && line.charCodeAt(i - 1) === 32) {
+      return i - 1;
+    }
+  }
+
+  return -1;
+}
 
 /**
  * parseMessage(line, stripColors)
@@ -36,19 +86,19 @@ export function parseMessage(
     line = stripColorsAndStyle(line);
   }
 
+  // IRCv3 message tags: https://modern.ircdocs.horse/#tags
+  let match = tagPrefixRegex.exec(line);
+  if (match) {
+    message.tags = parseTags(match[1]);
+    line = line.slice(match[0].length);
+  }
+
   // Parse prefix
-  let match = /^:([^ ]+) +/.exec(line);
+  match = sourcePrefixRegex.exec(line);
   if (match) {
     message.prefix = match[1];
-    line = line.replace(/^:[^ ]+ +/, '');
-    if (enableStrictParse) {
-      match = /^([_a-zA-Z0-9~[\]\\`^{}|-]*)(!([^@]+)@(.*))?$/.exec(message.prefix);
-    } else {
-      match =
-        /^([\u1100-\u11FF\u3040-\u309FF\u30A0-\u30FF\u3130-\u318F\u31F0-\u31FF\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF_a-zA-Z0-9~[\]\\/?`^{}|-]*)(!([^@]+)@(.*))?$/.exec(
-          message.prefix,
-        );
-    }
+    line = line.slice(match[0].length);
+    match = (enableStrictParse ? strictSourceRegex : looseSourceRegex).exec(message.prefix);
 
     if (match) {
       message.nick = match[1];
@@ -61,10 +111,11 @@ export function parseMessage(
 
   // Parse command
   match = /^([^ ]+) */.exec(line);
-  message.command = match?.[1];
-  message.rawCommand = match?.[1];
+  const rawCommand = match?.[1] ?? '';
+  message.command = rawCommand.toUpperCase() as CodeNames;
+  message.rawCommand = rawCommand.toUpperCase();
   message.commandType = 'normal';
-  line = line.replace(/^[^ ]+ +/, '');
+  line = line.slice(rawCommand.length).trimStart();
 
   const codeData = CODES[message.rawCommand as keyof typeof CODES];
   if (codeData) {
@@ -77,18 +128,18 @@ export function parseMessage(
 
   let middle: string | undefined = line;
   let trailing: string | undefined;
-  // Parse parameters
-  if (line.search(/^:|\s+:/) !== -1) {
-    match = /(.*?)(?:^:|\s+:)(.*)/.exec(line);
-    middle = match?.[1].trimEnd();
-    trailing = match?.[2];
+  // Parameters/trailing parameter: https://modern.ircdocs.horse/#parameters
+  const trailingStart = findTrailingStart(line);
+  if (trailingStart !== -1) {
+    middle = trailingStart === 0 ? '' : line.slice(0, trailingStart).trimEnd();
+    trailing = line.slice(trailingStart + (trailingStart === 0 ? 1 : 2));
   }
 
   if (middle?.length) {
     message.args = middle.split(/ +/);
   }
 
-  if (trailing?.length) {
+  if (typeof trailing === 'string') {
     message.args.push(trailing);
   }
 

--- a/test/handleData.spec.ts
+++ b/test/handleData.spec.ts
@@ -30,6 +30,26 @@ PING :EAA41EAE
 |chunk|`;
 
 describe('handle data', () => {
+  it('uses modern registration ordering for CAP, PASS, NICK, and USER', () => {
+    const client = setupMockClient('testbot', {
+      password: 'secret',
+      sasl: true,
+      userName: 'user',
+      realName: 'Real User',
+    });
+    const writeSpy = vi.spyOn(client.connection.socket, 'write');
+
+    // @ts-expect-error test private method
+    client._connectionHandler();
+
+    expect(writeSpy.mock.calls.map(call => call[0])).toEqual([
+      'CAP LS 302\r\n',
+      'PASS secret\r\n',
+      'NICK testbot\r\n',
+      'USER user 0 * :Real User\r\n',
+    ]);
+  });
+
   it('should handle initial connection', () => {
     const client = setupMockClient('testbot');
     const emitSpy = vi.spyOn(client, 'emit');
@@ -65,6 +85,69 @@ describe('handle data', () => {
       o: '@',
       q: '~',
       v: '+',
+    });
+  });
+
+  it('starts the client ping timer after registration completes', () => {
+    const client = setupMockClient('testbot');
+
+    client.handleData(':localhost 001 testbot :Welcome testbot!user@host\r\n');
+
+    expect(client.connection.cyclingPingTimer.start).toBeCalled();
+  });
+
+  it('emits the PONG token instead of the server parameter', () => {
+    const client = setupMockClient('testbot');
+    const emitSpy = vi.spyOn(client, 'emit');
+
+    client.handleData(':server PONG server :opaque-token\r\n');
+
+    expect(emitSpy).toBeCalledWith('pong', 'opaque-token');
+  });
+
+  it('ends CAP negotiation when SASL is unavailable, rejected, or fails', () => {
+    const client = setupMockClient('testbot', { sasl: true });
+    const writeSpy = vi.spyOn(client.connection.socket, 'write');
+    client.on('error', () => {});
+
+    client.handleData(':server CAP * LS :multi-prefix\r\n');
+    client.handleData(':server CAP * NAK :sasl\r\n');
+    client.handleData(':server 904 testbot :SASL authentication failed\r\n');
+
+    expect(writeSpy.mock.calls.map(call => call[0])).toEqual([
+      'CAP END\r\n',
+      'CAP END\r\n',
+      'CAP END\r\n',
+    ]);
+  });
+
+  it('keeps LIST data accurate without depending on RPL_LISTSTART', () => {
+    const client = setupMockClient('testbot');
+    const emitSpy = vi.spyOn(client, 'emit');
+
+    client.channellist = [
+      {
+        name: '#old',
+        users: {},
+        userCount: 99,
+      },
+    ];
+    client.handleData(':server 322 testbot #chan 7 :topic text\r\n');
+    client.handleData(':server 323 testbot :End of /LIST\r\n');
+
+    expect(client.channellist).toEqual([
+      {
+        name: '#chan',
+        topic: 'topic text',
+        userCount: 7,
+        users: {},
+      },
+    ]);
+    expect(emitSpy).toBeCalledWith('channellist_item', {
+      name: '#chan',
+      topic: 'topic text',
+      userCount: 7,
+      users: {},
     });
   });
 
@@ -154,5 +237,26 @@ describe('handle data', () => {
 
     expect(client.motd).toBe('MOTD File is missing\n');
     expect(emitSpy).toBeCalledWith('motd', 'MOTD File is missing\n');
+  });
+
+  it('processes complete lines before a later partial line completes', () => {
+    const client = setupMockClient('testbot');
+    const emitSpy = vi.spyOn(client, 'emit');
+
+    client.handleData('PING :a\r\n:server NOTICE');
+
+    expect(emitSpy).toBeCalledWith('ping', 'a');
+
+    client.handleData(' testbot :hello\r\n');
+
+    expect(emitSpy).toBeCalledWith(
+      'notice',
+      'server',
+      'testbot',
+      'hello',
+      expect.objectContaining({
+        command: 'NOTICE',
+      }),
+    );
   });
 });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -11,7 +11,7 @@ export function setupMockClient(nick: string, options?: Partial<IrcOptions>): Ir
     // @ts-expect-error mock
     socket: { write: vi.fn(), destroy: vi.fn() },
     // @ts-expect-error mock
-    cyclingPingTimer: { notifyOfActivity: vi.fn(), stop: vi.fn() },
+    cyclingPingTimer: { notifyOfActivity: vi.fn(), start: vi.fn(), stop: vi.fn() },
   };
   client.nick = nick;
 

--- a/test/mode.spec.ts
+++ b/test/mode.spec.ts
@@ -111,3 +111,28 @@ it('should handle adding and subtracting modes from user', () => {
     mode: 'j',
   });
 });
+
+it('should apply MODES and channel mode arguments from ISUPPORT and RPL_CHANNELMODEIS', () => {
+  const client = setupMockClient('testbot');
+  client.chans['#chan'] = {
+    key: '#chan',
+    mode: '',
+    modeParams: {},
+    serverName: '#chan',
+    users: {},
+  };
+
+  client.handleData(':server 005 testbot MODES=12 :are supported by this server\r\n');
+  client.handleData(':server 324 testbot #chan +kl secret 10\r\n');
+
+  expect(client.supported.modes).toBe(12);
+  expect(client.chans['#chan']).toEqual(
+    expect.objectContaining({
+      mode: '+kl',
+      modeParams: {
+        k: ['secret'],
+        l: ['10'],
+      },
+    }),
+  );
+});

--- a/test/mode.spec.ts
+++ b/test/mode.spec.ts
@@ -136,3 +136,26 @@ it('should apply MODES and channel mode arguments from ISUPPORT and RPL_CHANNELM
     }),
   );
 });
+
+it('should only consume RPL_CHANNELMODEIS arguments for parameterized modes', () => {
+  const client = setupMockClient('testbot');
+  client.chans['#chan'] = {
+    key: '#chan',
+    mode: '',
+    modeParams: {},
+    serverName: '#chan',
+    users: {},
+  };
+
+  client.handleData(':server 005 testbot CHANMODES=b,k,l,mn :are supported by this server\r\n');
+  client.handleData(':server 324 testbot #chan +mnl 50\r\n');
+
+  expect(client.chans['#chan']).toEqual(
+    expect.objectContaining({
+      mode: '+mnl',
+      modeParams: {
+        l: ['50'],
+      },
+    }),
+  );
+});

--- a/test/parseMessage.spec.ts
+++ b/test/parseMessage.spec.ts
@@ -23,3 +23,50 @@ for (const [message, result] of noprefix) {
     expect(parseMessage(message)).toEqual(result);
   });
 }
+
+it('parses IRCv3 message tags before the source and command', () => {
+  expect(
+    parseMessage('@aaa=bbb;ccc;escaped=hello\\sworld :nick!user@host PRIVMSG #chan :hi'),
+  ).toEqual({
+    args: ['#chan', 'hi'],
+    command: 'PRIVMSG',
+    commandType: 'normal',
+    host: 'host',
+    nick: 'nick',
+    prefix: 'nick!user@host',
+    rawCommand: 'PRIVMSG',
+    tags: {
+      aaa: 'bbb',
+      ccc: true,
+      escaped: 'hello world',
+    },
+    user: 'user',
+  });
+});
+
+it('keeps an empty trailing parameter', () => {
+  expect(parseMessage(':irc.example CAP * LIST :')).toEqual({
+    args: ['*', 'LIST', ''],
+    command: 'CAP',
+    commandType: 'normal',
+    prefix: 'irc.example',
+    rawCommand: 'CAP',
+    server: 'irc.example',
+  });
+});
+
+it('normalizes commands and does not invent parameters for command-only messages', () => {
+  expect(parseMessage('ping :token')).toEqual({
+    args: ['token'],
+    command: 'PING',
+    commandType: 'normal',
+    rawCommand: 'PING',
+  });
+
+  expect(parseMessage('PING')).toEqual({
+    args: [],
+    command: 'PING',
+    commandType: 'normal',
+    rawCommand: 'PING',
+  });
+});

--- a/test/userEvents.spec.ts
+++ b/test/userEvents.spec.ts
@@ -113,6 +113,26 @@ describe('user events', () => {
     client.handleData(':user5!~user3@example.host QUIT :See ya\r\n');
     expect(emitSpy).toBeCalledWith('quit', 'user5', 'See ya', ['#test2'], expect.anything());
   });
+
+  it('applies default channel membership prefixes before ISUPPORT', () => {
+    const client = setupMockClient('testbot');
+    client.chans['#chan'] = {
+      key: '#chan',
+      mode: '',
+      modeParams: {},
+      serverName: '#chan',
+      users: {},
+    };
+
+    client.handleData(':server 353 testbot = #chan :@oper +voice plain\r\n');
+
+    expect(client.chans['#chan'].users).toEqual({
+      oper: '@',
+      plain: '',
+      voice: '+',
+    });
+  });
+
   it('can leave a channel', () => {
     const client = setupMockClient('testbot');
     const emitSpy = vi.spyOn(client.connection.socket, 'write');
@@ -137,5 +157,24 @@ describe('user events', () => {
     client.notice('#test', 'heads up');
 
     expect(writeSpy).toBeCalledWith('NOTICE #test :heads up\r\n');
+  });
+
+  it('rejects raw line separators in outgoing parameters', () => {
+    const client = setupMockClient('testbot');
+
+    expect(() => client.send('PRIVMSG', '#test', 'hello\r\nOPER bad')).toThrow(
+      'IRC message parameters cannot contain NUL, CR, or LF characters',
+    );
+    expect(() => client.send('PRIVMSG', '#test', 'bad\0value')).toThrow(
+      'IRC message parameters cannot contain NUL, CR, or LF characters',
+    );
+  });
+
+  it('rejects oversized raw IRC messages', () => {
+    const client = setupMockClient('testbot');
+
+    expect(() => client.send('PRIVMSG', '#test', 'x'.repeat(512))).toThrow(
+      'IRC messages cannot exceed 512 bytes including CRLF',
+    );
   });
 });

--- a/test/whois.spec.ts
+++ b/test/whois.spec.ts
@@ -62,4 +62,19 @@ describe('whois', () => {
       }),
     );
   });
+
+  it('accumulates multiple whois channel batches', async () => {
+    const client = setupMockClient('testbot');
+    const promise = client.whois('friend');
+
+    client.handleData(':localhost 319 testbot friend :#one #two\r\n');
+    client.handleData(':localhost 319 testbot friend :#three\r\n');
+    client.handleData(':localhost 318 testbot friend :End of /WHOIS list.\r\n');
+
+    await expect(promise).resolves.toEqual(
+      expect.objectContaining({
+        channels: ['#one', '#two', '#three'],
+      }),
+    );
+  });
 });


### PR DESCRIPTION
Tightens up a handful of modern IRC protocol edges: tagged messages, empty trailing params, lowercase commands, LIST without 321, repeated WHOIS channel batches, PONG token handling, and default PREFIX/CHANTYPES handling.

Also keeps the newer input buffering hot path intact and moves the new coverage into the existing parser, handle-data, mode, user event, and whois tests.

Docs used while checking this: https://modern.ircdocs.horse/